### PR TITLE
add workflow for building and publishing docs

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,0 +1,39 @@
+name: Sphinx docs to gh-pages
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:        # Un comment line if you also want to trigger action manually
+
+jobs:
+  sphinx_docs_to_gh-pages:
+    runs-on: ubuntu-latest
+    name: Sphinx docs to gh-pages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Make conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.10"    # Python version to build the html sphinx documentation
+          # environment-file: doc/docs_env.yaml    # Path to the documentation conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Installing the library
+        shell: bash -l {0}
+        run: |
+          python -m pip install .
+          python -m pip install -r docs/requirements.txt
+          conda install -y pandoc
+      - name: Running the Sphinx to gh-pages Action
+        uses: uibcdf/action-sphinx-docs-to-gh-pages@v2.1.0
+        with:
+          branch: main
+          dir_docs: docs/source
+          sphinx-apidoc-opts: '--separate -o . ../'
+          sphinx-apidoc-exclude: '../*setup* ../*.ipynb'
+          sphinx-opts: ''


### PR DESCRIPTION
This will run sphinx and push the resulting HTML output to the gh-pages branch of your repo, where it can be accessed by users (see e.g. https://bmaranville.github.io/pyMACS/ )